### PR TITLE
Fix crash on spaces in tag properties, leak fixes and some cleanup

### DIFF
--- a/MDHTMLLabel/MDHTMLLabel.h
+++ b/MDHTMLLabel/MDHTMLLabel.h
@@ -81,7 +81,7 @@ For the most part, `MDHTMLLabel` behaves the same as `UILabel`. The following ar
 /**
  The receiver's delegate.
 
- @discussion A `TTTAttributedLabel` delegate responds to messages sent by tapping on links in the label. You can use the delegate to respond to links referencing a URL, address, phone number, date, or date with a specified time zone and duration.
+ @discussion A `MDHTMLLabelDelegate` delegate responds to messages sent by tapping on links in the label. You can use the delegate to respond to links referencing a URL, address, phone number, date, or date with a specified time zone and duration.
  */
 
 @property (nonatomic, weak) IBOutlet NSObject <MDHTMLLabelDelegate> *delegate;
@@ -178,7 +178,7 @@ For the most part, `MDHTMLLabel` behaves the same as `UILabel`. The following ar
 @property (nonatomic, assign) UIEdgeInsets textInsets;
 
 /**
- The vertical text alignment for the label, for when the frame size is greater than the text rect size. The vertical alignment is `TTTAttributedLabelVerticalAlignmentCenter` by default.
+ The vertical text alignment for the label, for when the frame size is greater than the text rect size. The vertical alignment is `MDHTMLLabelVerticalAlignmentCenter` by default.
  */
 @property (nonatomic, assign) MDHTMLLabelVerticalAlignment verticalAlignment;
 
@@ -189,7 +189,7 @@ For the most part, `MDHTMLLabel` behaves the same as `UILabel`. The following ar
 /**
  The truncation token that appears at the end of the truncated line. `nil` by default.
 
- @discussion When truncation is enabled for the label, by setting `lineBreakMode` to either `UILineBreakModeHeadTruncation`, `UILineBreakModeTailTruncation`, or `UILineBreakModeMiddleTruncation`, the token used to terminate the truncated line will be `truncationTokenString` if defined, otherwise the Unicode Character 'HORIZONTAL ELLIPSIS' (U+2026).
+ @discussion When truncation is enabled for the label, by setting `lineBreakMode` to either `NSLineBreakByTruncatingHead`, `NSLineBreakByTruncatingTail`, or `NSLineBreakByTruncatingMiddle`, the token used to terminate the truncated line will be `truncationTokenString` if defined, otherwise the Unicode Character 'HORIZONTAL ELLIPSIS' (U+2026).
  */
 @property (nonatomic, strong) NSString *truncationTokenString;
 

--- a/MDHTMLLabel/MDHTMLLabel.m
+++ b/MDHTMLLabel/MDHTMLLabel.m
@@ -29,7 +29,6 @@
 
 static CGFloat const MDFLOAT_MAX = 100000;
 
-#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 60000
 const NSTextAlignment MDTextAlignmentLeft = NSTextAlignmentLeft;
 const NSTextAlignment MDTextAlignmentCenter = NSTextAlignmentCenter;
 const NSTextAlignment MDTextAlignmentRight = NSTextAlignmentRight;
@@ -45,27 +44,9 @@ const NSLineBreakMode MDLineBreakByTruncatingTail = NSLineBreakByTruncatingTail;
 
 typedef NSTextAlignment MDTextAlignment;
 typedef NSLineBreakMode MDLineBreakMode;
-#else
-const UITextAlignment MDTextAlignmentLeft = NSTextAlignmentLeft;
-const UITextAlignment MDTextAlignmentCenter = NSTextAlignmentCenter;
-const UITextAlignment MDTextAlignmentRight = NSTextAlignmentRight;
-const UITextAlignment MDTextAlignmentJustified = NSTextAlignmentJustified;
-const UITextAlignment MDTextAlignmentNatural = NSTextAlignmentNatural;
-
-const UITextAlignment MDLineBreakByWordWrapping = NSLineBreakByWordWrapping;
-const UITextAlignment MDLineBreakByCharWrapping = NSLineBreakByCharWrapping;
-const UITextAlignment MDLineBreakByClipping = NSLineBreakByClipping;
-const UITextAlignment MDLineBreakByTruncatingHead = NSLineBreakByTruncatingHead;
-const UITextAlignment MDLineBreakByTruncatingMiddle = NSLineBreakByTruncatingMiddle;
-const UITextAlignment MDLineBreakByTruncatingTail = NSLineBreakByTruncatingTail;
-
-typedef UITextAlignment MDTextAlignment;
-typedef UILineBreakMode MDLineBreakMode;
-#endif
 
 static inline CTTextAlignment CTTextAlignmentFromMDTextAlignment(MDTextAlignment alignment)
 {
-#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 60000
     switch (alignment)
     {
 		case NSTextAlignmentLeft: return kCTLeftTextAlignment;
@@ -73,20 +54,10 @@ static inline CTTextAlignment CTTextAlignmentFromMDTextAlignment(MDTextAlignment
 		case NSTextAlignmentRight: return kCTRightTextAlignment;
 		default: return kCTNaturalTextAlignment;
 	}
-#else
-    switch (alignment)
-    {
-		case UITextAlignmentLeft: return kCTLeftTextAlignment;
-		case UITextAlignmentCenter: return kCTCenterTextAlignment;
-		case UITextAlignmentRight: return kCTRightTextAlignment;
-		default: return kCTNaturalTextAlignment;
-	}
-#endif
 }
 
 static inline CTLineBreakMode CTLineBreakModeFromMDLineBreakMode(MDLineBreakMode lineBreakMode)
 {
-#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 60000
 	switch (lineBreakMode)
     {
 		case NSLineBreakByWordWrapping: return kCTLineBreakByWordWrapping;
@@ -97,47 +68,6 @@ static inline CTLineBreakMode CTLineBreakModeFromMDLineBreakMode(MDLineBreakMode
 		case NSLineBreakByTruncatingMiddle: return kCTLineBreakByTruncatingMiddle;
 		default: return 0;
 	}
-#else
-    return CTLineBreakModeFromUILineBreakMode(lineBreakMode);
-#endif
-}
-
-static inline CTLineBreakMode CTLineBreakModeFromUILineBreakMode(UILineBreakMode lineBreakMode)
-{
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    switch (lineBreakMode)
-    {
-        case UILineBreakModeWordWrap: return kCTLineBreakByWordWrapping;
-        case UILineBreakModeCharacterWrap: return kCTLineBreakByCharWrapping;
-        case UILineBreakModeClip: return kCTLineBreakByClipping;
-        case UILineBreakModeHeadTruncation: return kCTLineBreakByTruncatingHead;
-        case UILineBreakModeTailTruncation: return kCTLineBreakByTruncatingTail;
-        case UILineBreakModeMiddleTruncation: return kCTLineBreakByTruncatingMiddle;
-        default: return 0;
-    }
-#pragma clang diagnostic pop
-}
-
-static inline UILineBreakMode UILineBreakModeFromMDLineBreakMode(MDLineBreakMode lineBreakMode)
-{
-#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 60000
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-	switch (lineBreakMode)
-    {
-		case NSLineBreakByWordWrapping: return UILineBreakModeWordWrap;
-		case NSLineBreakByCharWrapping: return UILineBreakModeCharacterWrap;
-		case NSLineBreakByClipping: return UILineBreakModeClip;
-		case NSLineBreakByTruncatingHead: return UILineBreakModeHeadTruncation;
-		case NSLineBreakByTruncatingTail: return UILineBreakModeMiddleTruncation;
-		case NSLineBreakByTruncatingMiddle: return UILineBreakModeTailTruncation;
-		default: return 0;
-	}
-#pragma clang diagnostic pop
-#else
-    return lineBreakMode;
-#endif
 }
 
 static inline CFRange CFRangeFromNSRange(NSRange range)

--- a/MDHTMLLabel/MDHTMLLabel.m
+++ b/MDHTMLLabel/MDHTMLLabel.m
@@ -389,6 +389,10 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
     {
         CFRelease(_framesetter);
     }
+    if (_highlightFramesetter)
+    {
+        CFRelease(_highlightFramesetter);
+    }
 }
 
 #pragma mark - Accessors
@@ -907,8 +911,9 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
         }
     }
 
-
-    return (__bridge NSAttributedString *)attrString;
+	NSAttributedString *styledString = [[NSAttributedString alloc] initWithAttributedString:(__bridge NSAttributedString *)attrString];
+	CFRelease(attrString);
+    return styledString;
 }
 
 - (void)applyParagraphStyleToText:(CFMutableAttributedStringRef)text


### PR DESCRIPTION
I was digging in to fix a crash I was getting and cleaned up a few pre-iOS 6 things that I'm guessing came from RT. I found a couple of leaks but didn't do an exhaustive search. The main problem I had was around spaces in attributes. As ugly as this is, it's valid:
`<a    href = "    http://Google.com     "    >Google</a>`

The first problem I fixed was the link detection code was expecting exactly href=' so I made it more flexible.
Second, the crash was because extra splices cause the components by " " to make too many array elements with the key value pair all split up. I've made it more forgiving. 
