### PR TITLE
restore wrappedInAnchors, it shouldn't have been removed

### DIFF
--- a/MDHTMLLabel/MDHTMLLabel.m
+++ b/MDHTMLLabel/MDHTMLLabel.m
@@ -1657,8 +1657,10 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
 							  (prevEndTagRange.location == NSNotFound || (prevEndTagRange.location != NSNotFound &&
 																		   prevStartATagRange.location >= NSMaxRange(prevEndTagRange))));
 			}
+			
+            BOOL wrappedInAnchors = [text rangeOfString:@"a>" options:NSCaseInsensitiveSearch | NSBackwardsSearch range:match.range].location != NSNotFound;
 
-            if (!insideHref)
+            if (!insideHref && !wrappedInAnchors)
             {
                 NSString *wrappedURL = [NSString stringWithFormat:@"<a href='%@'>%@</a>", match.URL.absoluteString, match.URL.absoluteString];
                 text = [text stringByReplacingCharactersInRange:match.range


### PR DESCRIPTION
Sorry I pulled this out last time but didn't see the case it prevents. This now stops double links in the case of this html:
`<a href="http://google.com">http://google.com</a>`
