### PR TITLE
Custom fonts on bold, italic, bold italic

### DIFF
--- a/MDHTMLLabel/MDHTMLLabel.h
+++ b/MDHTMLLabel/MDHTMLLabel.h
@@ -143,6 +143,23 @@ For the most part, `MDHTMLLabel` behaves the same as `UILabel`. The following ar
  */
 @property (nonatomic, strong) UIColor *highlightedShadowColor;
 
+
+/**
+ The font name of the custom font which should be used for bold text. If not set the system bold font will be used.
+*/
+@property(nonatomic, copy) NSString *customBoldFontName;
+
+/**
+ The font name of the custom font which should be used for italic text. If not set the system italic font will be used.
+*/
+@property(nonatomic, copy) NSString *customItalicFontName;
+
+/**
+ The font name of the custom font which should be used for bold italic text. If not set the system font with style BoldOblique will be used.
+*/
+@property(nonatomic, copy) NSString *customBoldItalicFontName;
+
+
 ///--------------------------------------------
 /// @name Acccessing Paragraph Style Attributes
 ///--------------------------------------------
@@ -203,7 +220,7 @@ For the most part, `MDHTMLLabel` behaves the same as `UILabel`. The following ar
 /// @name Calculating Size of HTML String
 ///--------------------------------------------
 
-@property(nonatomic, copy) NSString *customBoldFontName;
+
 
 /**
  Calculate and return the size that best fits a HTML string, given the specified constraints on size and number of lines.

--- a/MDHTMLLabel/MDHTMLLabel.h
+++ b/MDHTMLLabel/MDHTMLLabel.h
@@ -203,6 +203,8 @@ For the most part, `MDHTMLLabel` behaves the same as `UILabel`. The following ar
 /// @name Calculating Size of HTML String
 ///--------------------------------------------
 
+@property(nonatomic, copy) NSString *customBoldFontName;
+
 /**
  Calculate and return the size that best fits a HTML string, given the specified constraints on size and number of lines.
 

--- a/MDHTMLLabel/MDHTMLLabel.m
+++ b/MDHTMLLabel/MDHTMLLabel.m
@@ -1072,9 +1072,10 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
     CFTypeRef actualFontRef = CFAttributedStringGetAttribute(text, range.location, kCTFontAttributeName, NULL);
     CTFontRef italicFontRef = CTFontCreateCopyWithSymbolicTraits(actualFontRef, 0.0, NULL, kCTFontItalicTrait, kCTFontItalicTrait);
 
-    if (!italicFontRef)
+    BOOL forceCustomFont = self.customItalicFontName;
+    if (!italicFontRef || forceCustomFont)
     {
-        UIFont *font = [UIFont italicSystemFontOfSize:CTFontGetSize(actualFontRef)];
+        UIFont *font = [self italicFontOfSize:CTFontGetSize(actualFontRef)];
         italicFontRef = CTFontCreateWithName ((__bridge CFStringRef)[font fontName], [font pointSize], NULL);
     }
 
@@ -1194,8 +1195,8 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
     CFTypeRef actualFontRef = CFAttributedStringGetAttribute(text, range.location, kCTFontAttributeName, NULL);
     CTFontRef boldFontRef = CTFontCreateCopyWithSymbolicTraits(actualFontRef, 0.0, NULL, kCTFontBoldTrait, kCTFontBoldTrait);
 
-    BOOL forceNewBoldFonRefOnCustomBoldFont = self.customBoldFontName;
-    if (!boldFontRef || forceNewBoldFonRefOnCustomBoldFont)
+    BOOL forceCustomFont = self.customBoldFontName;
+    if (!boldFontRef || forceCustomFont)
     {
 //        UIFont *font = [UIFont boldSystemFontOfSize:CTFontGetSize(actualFontRef)];
         UIFont *font = [self boldFontOfSize:CTFontGetSize(actualFontRef)];
@@ -1213,10 +1214,12 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
     CFTypeRef actualFontRef = CFAttributedStringGetAttribute(text, range.location, kCTFontAttributeName, NULL);
     CTFontRef boldItalicFontRef = CTFontCreateCopyWithSymbolicTraits(actualFontRef, 0.0, NULL, kCTFontBoldTrait | kCTFontItalicTrait , kCTFontBoldTrait | kCTFontItalicTrait);
 
-    if (!boldItalicFontRef)
+    BOOL forceCustomFont = self.customBoldItalicFontName;
+    if (!boldItalicFontRef || forceCustomFont)
     {
-        NSString *fontName = [NSString stringWithFormat:@"%@-BoldOblique", self.font.fontName];
-        boldItalicFontRef = CTFontCreateWithName((__bridge CFStringRef)fontName, self.font.pointSize, NULL);
+//        NSString *fontName = [NSString stringWithFormat:@"%@-BoldOblique", self.font.fontName];
+        UIFont *font = [self boldItalicFontOfSize:CTFontGetSize(actualFontRef)];
+        boldItalicFontRef = CTFontCreateWithName((__bridge CFStringRef)font.fontName, self.font.pointSize, NULL);
     }
 
     if (boldItalicFontRef)
@@ -2026,9 +2029,22 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
 #pragma mark - Custom fonts
 - (UIFont *)boldFontOfSize:(CGFloat)size {
     if (self.customBoldFontName) {
-        NSLog(@"Returning custom bold font by name %@", self.customBoldFontName);
         return [UIFont fontWithName:self.customBoldFontName size:size];
     }
     return [UIFont boldSystemFontOfSize:size];
+}
+
+- (UIFont *)italicFontOfSize:(CGFloat)size {
+    if (self.customItalicFontName) {
+        return [UIFont fontWithName:self.customItalicFontName size:size];
+    }
+    return [UIFont italicSystemFontOfSize:size];
+}
+
+- (UIFont *)boldItalicFontOfSize:(CGFloat)size {
+    if (self.customBoldItalicFontName) {
+        return [UIFont fontWithName:self.customBoldItalicFontName size:size];
+    }
+    return [UIFont fontWithName:[NSString stringWithFormat:@"%@-BoldOblique", self.font.fontName] size:size];
 }
 @end

--- a/MDHTMLLabel/MDHTMLLabel.m
+++ b/MDHTMLLabel/MDHTMLLabel.m
@@ -1194,7 +1194,8 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
     CFTypeRef actualFontRef = CFAttributedStringGetAttribute(text, range.location, kCTFontAttributeName, NULL);
     CTFontRef boldFontRef = CTFontCreateCopyWithSymbolicTraits(actualFontRef, 0.0, NULL, kCTFontBoldTrait, kCTFontBoldTrait);
 
-    if (!boldFontRef)
+    BOOL forceNewBoldFonRefOnCustomBoldFont = self.customBoldFontName;
+    if (!boldFontRef || forceNewBoldFonRefOnCustomBoldFont)
     {
 //        UIFont *font = [UIFont boldSystemFontOfSize:CTFontGetSize(actualFontRef)];
         UIFont *font = [self boldFontOfSize:CTFontGetSize(actualFontRef)];
@@ -2025,6 +2026,7 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
 #pragma mark - Custom fonts
 - (UIFont *)boldFontOfSize:(CGFloat)size {
     if (self.customBoldFontName) {
+        NSLog(@"Returning custom bold font by name %@", self.customBoldFontName);
         return [UIFont fontWithName:self.customBoldFontName size:size];
     }
     return [UIFont boldSystemFontOfSize:size];

--- a/MDHTMLLabel/MDHTMLLabel.m
+++ b/MDHTMLLabel/MDHTMLLabel.m
@@ -1196,7 +1196,8 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
 
     if (!boldFontRef)
     {
-        UIFont *font = [UIFont boldSystemFontOfSize:CTFontGetSize(actualFontRef)];
+//        UIFont *font = [UIFont boldSystemFontOfSize:CTFontGetSize(actualFontRef)];
+        UIFont *font = [self boldFontOfSize:CTFontGetSize(actualFontRef)];
         boldFontRef = CTFontCreateWithName((__bridge CFStringRef)font.fontName, self.font.pointSize, NULL);
     }
 
@@ -2021,4 +2022,11 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
     return self;
 }
 
+#pragma mark - Custom fonts
+- (UIFont *)boldFontOfSize:(CGFloat)size {
+    if (self.customBoldFontName) {
+        return [UIFont fontWithName:self.customBoldFontName size:size];
+    }
+    return [UIFont boldSystemFontOfSize:size];
+}
 @end


### PR DESCRIPTION
Added the ability to define custom fonts for following text styles:
- bold
- italic
- bold italic

Custom fonts are triggered and configured through the three new properties:
- customBoldFontName
- customItalicFontName
- customBoldItalicFontName

If one of these is set the custom fonts will be used instead of the given system fonts.
