### PR TITLE
prevent crash

### DIFF
--- a/MDHTMLLabel/MDHTMLLabel.m
+++ b/MDHTMLLabel/MDHTMLLabel.m
@@ -836,6 +836,11 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
         NSInteger index = [styleComponents indexOfObject:component];
         component.componentIndex = index;
 
+        if (component.range.location == NSNotFound || component.range.length == 0) {
+            // ignore bad tags, like <b><b>
+            continue;
+        }
+
         if ([component.htmlTag caseInsensitiveCompare:@"i"] == NSOrderedSame)
         {
             [self applyItalicStyleToText:attrString


### PR DESCRIPTION
If the component looks bad, skip it.

This is for https://github.com/mattdonnelly/MDHTMLLabel/issues/24

@mattdonnelly and @aprato, what do you think?
