### PR TITLE
autoDetectUrls needed for sizeThatFitsHTMLString as well

### DIFF
--- a/MDHTMLLabel/MDHTMLLabel.h
+++ b/MDHTMLLabel/MDHTMLLabel.h
@@ -230,12 +230,14 @@ For the most part, `MDHTMLLabel` behaves the same as `UILabel`. The following ar
  @param font - the font to render the string with
  @param size - the size to constrain the string to
  @param numberOfLines - the number of lines to limit the string to
+ @param autoDetectUrls - detect URLs
 
  @return The size that fits the HTML string within the specified constraints.
  */
 + (CGFloat)sizeThatFitsHTMLString:(NSString *)htmlString
                          withFont:(UIFont *)font
                       constraints:(CGSize)size
-           limitedToNumberOfLines:(NSUInteger)numberOfLines;
+           limitedToNumberOfLines:(NSUInteger)numberOfLines
+                   autoDetectUrls:(BOOL)autoDetectUrls;
 
 @end

--- a/MDHTMLLabel/MDHTMLLabel.m
+++ b/MDHTMLLabel/MDHTMLLabel.m
@@ -1567,11 +1567,13 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
                          withFont:(UIFont *)font
                       constraints:(CGSize)size
            limitedToNumberOfLines:(NSUInteger)numberOfLines
+                   autoDetectUrls:(BOOL)autoDetectUrls
 {
     MDHTMLLabel *label = [[MDHTMLLabel alloc] initWithFrame:CGRectMake(0.0, 0.0, size.width, size.height)];
     label.font = font;
     label.numberOfLines = numberOfLines;
     label.lineBreakMode = NSLineBreakByWordWrapping;
+    label.autoDetectUrls = autoDetectUrls;
     label.htmlText = htmlString;
 
     return [label sizeThatFits:size].height;


### PR DESCRIPTION
@mattdonnelly @yinsee 

this is a follow up to https://github.com/mattdonnelly/MDHTMLLabel/commit/054eb3d6244ddafa46d8e40a0f269b031969fd15

you'll want this as well, so that if you decide to disable autoDetectUrls, you can also disable it when calling sizeThatFitsHTMLString.

This is needed for correctness, but also performance, if you use MDHTMLLabel in a table view cell, you probably don't want to invoke the NSDataDetector as it can be slow.
